### PR TITLE
支持middleware match配置多个group

### DIFF
--- a/src/Middleware/MiddlewareConfig.php
+++ b/src/Middleware/MiddlewareConfig.php
@@ -71,6 +71,20 @@ class MiddlewareConfig
         if (null === $groupKey) {
             return [];
         }
+
+        if (is_array($groupKey)) {
+            $configGroupKey = [];
+            foreach ($groupKey as $key) {
+                if (!isset($config['group'][$key])) {
+                    throw new InvalidArgumentException('Invalid Group name in MiddlewareManager, see: http://zanphpdoc.zanphp.io/libs/middleware/filters.html#tcp');
+                }
+                foreach ($config['group'][$key] as $item) {
+                    $configGroupKey[] = $item;
+                }
+            }
+            return $configGroupKey;
+        }
+
         if (!isset($config['group'][$groupKey])) {
             throw new InvalidArgumentException('Invalid Group name in MiddlewareManager, see: http://zanphpdoc.zanphp.io/libs/middleware/filters.html#tcp');
         }

--- a/src/Middleware/MiddlewareConfig.php
+++ b/src/Middleware/MiddlewareConfig.php
@@ -72,24 +72,17 @@ class MiddlewareConfig
             return [];
         }
 
-        if (is_array($groupKey)) {
-            $configGroupKey = [];
-            foreach ($groupKey as $key) {
-                if (!isset($config['group'][$key])) {
-                    throw new InvalidArgumentException('Invalid Group name in MiddlewareManager, see: http://zanphpdoc.zanphp.io/libs/middleware/filters.html#tcp');
-                }
-                foreach ($config['group'][$key] as $item) {
-                    $configGroupKey[] = $item;
-                }
+        $groupKeys = is_array($groupKey) ? $groupKey : [$groupKey];
+        $configGroupKey = [];
+        foreach ($groupKeys as $key) {
+            if (!isset($config['group'][$key])) {
+                throw new InvalidArgumentException('Invalid Group name in MiddlewareManager, see: http://zanphpdoc.zanphp.io/libs/middleware/filters.html#tcp');
             }
-            return $configGroupKey;
+            foreach ($config['group'][$key] as $item) {
+                $configGroupKey[] = $item;
+            }
         }
-
-        if (!isset($config['group'][$groupKey])) {
-            throw new InvalidArgumentException('Invalid Group name in MiddlewareManager, see: http://zanphpdoc.zanphp.io/libs/middleware/filters.html#tcp');
-        }
-
-        return $config['group'][$groupKey];
+        return array_unique($configGroupKey);
     }
 
     public function getRequestFilters($request)


### PR DESCRIPTION
支持middleware match配置多个group(以数组形式)
```php
<?php
return [
    'match' => [
        [
            "/com/Yourcompany/nova/framework/generic/service/GenericService/invoke", ["genericServiceFilterGroup", "anotherGroup"],
        ]
    ],
    'group' => [
        "genericServiceFilterGroup" => [genericServiceFilter::class],
        "anotherGroup" => [anotherGroupFilter::class],
    ]
];

```